### PR TITLE
fix:  Found wrong number (0) of indexes

### DIFF
--- a/django_cron/migrations/0004_alter_cronjoblog_options_and_more.py
+++ b/django_cron/migrations/0004_alter_cronjoblog_options_and_more.py
@@ -14,21 +14,21 @@ class Migration(migrations.Migration):
             name='cronjoblog',
             options={'get_latest_by': 'start_time'},
         ),
-        migrations.RenameIndex(
-            model_name='cronjoblog',
-            new_name='django_cron_code_966ed3_idx',
-            old_fields=('code', 'start_time'),
-        ),
-        migrations.RenameIndex(
-            model_name='cronjoblog',
-            new_name='django_cron_code_21f381_idx',
-            old_fields=('code', 'start_time', 'ran_at_time'),
-        ),
-        migrations.RenameIndex(
-            model_name='cronjoblog',
-            new_name='django_cron_code_89ad04_idx',
-            old_fields=('code', 'is_success', 'ran_at_time'),
-        ),
+        # migrations.RenameIndex(
+        #     model_name='cronjoblog',
+        #     new_name='django_cron_code_966ed3_idx',
+        #     old_fields=('code', 'start_time'),
+        # ),
+        # migrations.RenameIndex(
+        #     model_name='cronjoblog',
+        #     new_name='django_cron_code_21f381_idx',
+        #     old_fields=('code', 'start_time', 'ran_at_time'),
+        # ),
+        # migrations.RenameIndex(
+        #     model_name='cronjoblog',
+        #     new_name='django_cron_code_89ad04_idx',
+        #     old_fields=('code', 'is_success', 'ran_at_time'),
+        # ),
         migrations.AlterField(
             model_name='cronjoblog',
             name='code',


### PR DESCRIPTION
Since you've removed the indexes from [there](https://github.com/jorenham/django-cron/blob/master/django_cron/migrations/0001_initial.py#L37-L46), we also need to remove the renaming operations for those indexes here.